### PR TITLE
Implement a workaround exported csv files

### DIFF
--- a/ego/tools/utilities.py
+++ b/ego/tools/utilities.py
@@ -19,6 +19,7 @@
 # File description
 """This module contains utility functions for the eGo application.
 """
+import csv
 import os
 import pandas as pd
 import json
@@ -116,6 +117,27 @@ def get_scenario_setting(jsonpath='scenario_setting.json'):
 
     return json_file
 
+def fix_leading_separator(csv_file, **kwargs):
+    """
+    Takes the path to a csv-file. If the first line this file has a leading
+    separator in its header, this field is deleted. If this is done the second
+    field of every row is removed, too.
+    """
+    with open(csv_file,'r') as f:
+        lines = csv.reader(f,**kwargs)
+        if not lines:
+            raise Exception('File %s contained no data'%csv_file)
+        first_line = next(lines)
+        if first_line[0] == '':
+            tmp_file = 'tmp_' + csv_file
+            with open(tmp_file) as out:
+                writer = csv.writer(out, **kwargs)
+                writer.writerow(first_line[1:])
+                for line in lines:
+                    l = line[2:]
+                    l.insert(0,line[0])
+                    writer.writerow(l, **kwargs)
+            os.rename(tmp_file, csv_file)
 
 def get_time_steps(json_file):
     """ Get time step of calculation by scenario settings.


### PR DESCRIPTION
Some bug causes csv-files to include leading whitespaces and adds an aditional
second column, which leads to faulty results on import.
This new function checks if a passed file is subject to this error and tries to
repair it.