### PR TITLE
Features/storage test

### DIFF
--- a/ego/tools/edisgo_integration.py
+++ b/ego/tools/edisgo_integration.py
@@ -186,7 +186,11 @@ class EDisGoNetworks:
         Session = scoped_session(session_factory)
         session = Session()
         
-        return self._get_mv_grid_from_bus_id(session, bus_id)  
+        mv_grid_id = self._get_mv_grid_from_bus_id(session, bus_id)
+        
+        Session.remove()
+        
+        return mv_grid_id
 
     def get_bus_id_from_mv_grid(self, subst_id):
         """
@@ -209,7 +213,11 @@ class EDisGoNetworks:
         Session = scoped_session(session_factory)
         session = Session()
         
-        return self._get_bus_id_from_mv_grid(session, subst_id)
+        bus_id = self._get_bus_id_from_mv_grid(session, subst_id)
+        
+        Session.remove()
+        
+        return bus_id
     
     def _update_edisgo_configs(self, edisgo_grid):
         
@@ -297,7 +305,6 @@ class EDisGoNetworks:
 
         # eDisGo args import
         if self._csv_import:
-            #            raise NotImplementedError
 
             with open(os.path.join(
                     self._csv_import,

--- a/ego/tools/edisgo_integration.py
+++ b/ego/tools/edisgo_integration.py
@@ -82,7 +82,6 @@ class EDisGoNetworks:
 
         # Create reduced eTraGo network
         self._etrago_network = _ETraGoData(etrago_network)
-        del etrago_network
 
         # eDisGo specific naming
         self._edisgo_scenario_translation()
@@ -163,6 +162,52 @@ class EDisGoNetworks:
 
         """
         return self._grid_investment_costs
+    
+    def get_mv_grid_from_bus_id(self, bus_id):
+        """
+        Queries the MV grid ID for a given eTraGo bus
+
+        Parameters
+        ----------
+        bus_id : int
+            eTraGo bus ID
+
+        Returns
+        -------
+        int
+            MV grid (ding0) ID
+
+        """
+        
+        conn = db.connection(section=self._db_section)
+        session_factory = sessionmaker(bind=conn)
+        Session = scoped_session(session_factory)
+        session = Session()
+        
+        return self._get_mv_grid_from_bus_id(session, bus_id)  
+
+    def get_bus_id_from_mv_grid(self, subst_id):
+        """
+        Queries the eTraGo bus ID for given MV grid (ding0) ID
+
+        Parameters
+        ----------
+        subst_id : int
+            MV grid (ding0) ID
+
+        Returns
+        -------
+        int
+            eTraGo bus ID
+
+        """
+        
+        conn = db.connection(section=self._db_section)
+        session_factory = sessionmaker(bind=conn)
+        Session = scoped_session(session_factory)
+        session = Session()
+        
+        return self._get_bus_id_from_mv_grid(session, subst_id)
     
     def _update_edisgo_configs(self, edisgo_grid):
         

--- a/ego/tools/io.py
+++ b/ego/tools/io.py
@@ -484,6 +484,24 @@ class eGo(eDisGoResults):
         self._ehv_grid_costs = _grid_ehv
         self._mv_grid_costs = _grid_mv_lv
 
+
+    def _calculate_mv_storage_investment(self):
+        """
+        """
+        # Total investment costs
+        etrago_network = self._etrago_disaggregated_network
+        
+        ## This should query only the storages relevant for
+        ## MV grids
+        min_extended = 0.3
+        stor_df = etrago_network.storage_units.loc[
+            (etrago_network.storage_units['p_nom_extendable'] == True)
+            & (etrago_network.storage_units['p_nom_opt'] > min_extended)
+            & (etrago_network.storage_units['max_hours'] <= 20.)]
+        
+        
+        
+        
     @property
     def total_investment_costs(self):
         """

--- a/ego/tools/io.py
+++ b/ego/tools/io.py
@@ -485,10 +485,25 @@ class eGo(eDisGoResults):
         self._mv_grid_costs = _grid_mv_lv
 
 
+    def _calculate_all_extended_storages(self):
+        """
+        Returns the all extended storage p_nom_opt in MW
+        """
+        etrago_network = self._etrago_disaggregated_network
+
+        stor_df = etrago_network.storage_units.loc[
+            (etrago_network.storage_units['p_nom_extendable'] == True)]
+        
+        stor_df = stor_df[['bus', 'p_nom_opt']]
+        
+        all_extended_storages = stor_df['p_nom_opt'].sum()
+        
+        return all_extended_storages
+               
     def _calculate_mv_storage(self):
         """
+        Returns the storage p_nom_opt in MW, integrated in MV grids
         """
-        # Total investment costs
         etrago_network = self._etrago_disaggregated_network
         
         min_extended = 0.3
@@ -496,11 +511,7 @@ class eGo(eDisGoResults):
             (etrago_network.storage_units['p_nom_extendable'] == True)
             & (etrago_network.storage_units['p_nom_opt'] > min_extended)
             & (etrago_network.storage_units['max_hours'] <= 20.)]
-        
-        # Only MV-grid relevant battery storages
-#        stor_df['investment_costs'] = (
-#                stor_df['capital_cost'] * stor_df['p_nom_opt'])
-        
+               
         stor_df = stor_df[['bus', 'p_nom_opt']]
         
         integrated_storage = .0 # Storage integrated in MV grids
@@ -510,9 +521,13 @@ class eGo(eDisGoResults):
             p_nom_opt = row['p_nom_opt']
             
             mv_grid_id = self.edisgo.get_mv_grid_from_bus_id(bus_id)
+            
             if not mv_grid_id:
                 continue
             
+            logger.info("Checking storage integration for MV grid {}".format(
+                    mv_grid_id))
+                        
             grid_choice = self.edisgo.grid_choice
             
             cluster = grid_choice.loc[
@@ -525,25 +540,19 @@ class eGo(eDisGoResults):
             else:
                 representative_grid = cluster[
                         'the_selected_network_id'].values[0]
+                
+            integration_df = self.edisgo.network[
+                    representative_grid].network.results.storages()
+                       
+            integrated_power = integration_df['nominal_power'].sum() / 1000
+            if integrated_power > p_nom_opt:
+                integrated_power = p_nom_opt
             
+            integrated_storage = integrated_storage + integrated_power
             
+        return integrated_storage
             
-            [
-                            'the_selected_network_id']
-            if len(representative) == 0:
-
-
-#    
-#            #evaaaaaal!!!
-#        
-#        
-        
-        
-        
-        
-        
-        
-        
+   
     @property
     def total_investment_costs(self):
         """
@@ -569,19 +578,64 @@ class eGo(eDisGoResults):
 
         """
         return self._total_operation_costs
-
-    def plot_total_investment_costs(self, filename=None,
+    
+    def plot_total_investment_costs(self, 
+                                    storage_integration=True,
+                                    filename=None,
                                     display=False, **kwargs):
         """ Plot total investment costs
         """
         # initiate total_investment_costs
         self.get_investment_cost
-
+        costs_df = self._total_investment_costs
+        
+        if storage_integration:
+            total_stor = self._calculate_all_extended_storages()
+            mv_stor = self._calculate_mv_storage()
+            
+            integrated_share = mv_stor / total_stor
+            
+            if integrated_share > 0:    
+                ehv_stor_idx = costs_df.index[
+                        (costs_df['component'] == 'storage')
+                        & (costs_df['voltage_level'] == 'ehv')][0]
+                                        
+                int_capital_costs = costs_df.loc[ehv_stor_idx][
+                                'capital_cost'
+                                ] * integrated_share
+                int_overnight_costs =  costs_df.loc[ehv_stor_idx][
+                                'overnight_costs'
+                                ] * integrated_share  
+                                                            
+                costs_df.at[
+                        ehv_stor_idx, 
+                        'capital_cost'
+                        ] = (
+                        costs_df.loc[ehv_stor_idx]['capital_cost']
+                        - int_capital_costs)
+                                                            
+                costs_df.at[
+                        ehv_stor_idx, 
+                        'overnight_costs'
+                        ] = (
+                        costs_df.loc[ehv_stor_idx]['overnight_costs']
+                        - int_overnight_costs)        
+        
+                new_storage_row = {
+                        'component' : ['storage'],
+                        'voltage_level' : ['mv'],
+                        'capital_cost' : [int_capital_costs],
+                        'overnight_costs' : [int_overnight_costs]}  
+                
+                new_storage_row = pd.DataFrame(new_storage_row)
+                costs_df = costs_df.append(new_storage_row)
+        
+         
         if filename is None:
             filename = "results/plot_total_investment_costs.pdf"
             display = True
 
-        return grid_storage_investment(self, filename=filename,
+        return grid_storage_investment(costs_df, filename=filename,
                                        display=display, **kwargs)
 
     def plot_power_price(self, filename=None, display=False):

--- a/ego/tools/io.py
+++ b/ego/tools/io.py
@@ -485,19 +485,61 @@ class eGo(eDisGoResults):
         self._mv_grid_costs = _grid_mv_lv
 
 
-    def _calculate_mv_storage_investment(self):
+    def _calculate_mv_storage(self):
         """
         """
         # Total investment costs
         etrago_network = self._etrago_disaggregated_network
         
-        ## This should query only the storages relevant for
-        ## MV grids
         min_extended = 0.3
         stor_df = etrago_network.storage_units.loc[
             (etrago_network.storage_units['p_nom_extendable'] == True)
             & (etrago_network.storage_units['p_nom_opt'] > min_extended)
             & (etrago_network.storage_units['max_hours'] <= 20.)]
+        
+        # Only MV-grid relevant battery storages
+#        stor_df['investment_costs'] = (
+#                stor_df['capital_cost'] * stor_df['p_nom_opt'])
+        
+        stor_df = stor_df[['bus', 'p_nom_opt']]
+        
+        integrated_storage = .0 # Storage integrated in MV grids
+        
+        for idx, row in stor_df.iterrows():
+            bus_id = row['bus']
+            p_nom_opt = row['p_nom_opt']
+            
+            mv_grid_id = self.edisgo.get_mv_grid_from_bus_id(bus_id)
+            if not mv_grid_id:
+                continue
+            
+            grid_choice = self.edisgo.grid_choice
+            
+            cluster = grid_choice.loc[
+                    [mv_grid_id in repr_grids for repr_grids in grid_choice[
+                            'represented_grids']]]
+            
+            if len(cluster) == 0:
+                continue
+                
+            else:
+                representative_grid = cluster[
+                        'the_selected_network_id'].values[0]
+            
+            
+            
+            [
+                            'the_selected_network_id']
+            if len(representative) == 0:
+
+
+#    
+#            #evaaaaaal!!!
+#        
+#        
+        
+        
+        
         
         
         

--- a/ego/tools/plots.py
+++ b/ego/tools/plots.py
@@ -98,7 +98,7 @@ def ego_colore():
     return colors
 
 
-def grid_storage_investment(ego, filename, display, var=None):
+def grid_storage_investment(costs_df, filename, display, var=None):
     """
     """
     colors = ego_colore()
@@ -106,7 +106,7 @@ def grid_storage_investment(ego, filename, display, var=None):
     opacity = 0.4
 
     if var == 'overnight_cost':
-        tic = ego.total_investment_costs[['component',
+        tic = costs_df[['component',
                                           'overnight_costs', 'voltage_level']]
         tic.set_index(['voltage_level', 'component'], inplace=True)
         ax = tic.unstack().plot(kind='bar',
@@ -121,7 +121,7 @@ def grid_storage_investment(ego, filename, display, var=None):
                      "voltage level and component", y=1.08)
 
     else:
-        tic = ego.total_investment_costs[['component',
+        tic = costs_df[['component',
                                           'capital_cost', 'voltage_level']]
         tic.set_index(['voltage_level', 'component'], inplace=True)
         ax = tic.unstack().plot(kind='bar',


### PR DESCRIPTION
* With this feature, the total investment costs can (optionally) be modified in order to consider storage units installed in MV grids.
@wolfbunke in detail: The class attribute `self._total_investment_costs` gets modified by: https://github.com/openego/eGo/blob/b8b10b9789dddf14462e10e730f395df4b7b67ae/ego/tools/io.py#L485-L487.
However, the function https://github.com/openego/eGo/blob/b8b10b9789dddf14462e10e730f395df4b7b67ae/ego/tools/io.py#L442 is not executed automatically in order to prepare all results, before the actual plots are made. @wolfbunke, can you implement this change (to calculate all values only once) in the next days?