### PR TITLE
Integrate eTraGo

### DIFF
--- a/ego/scenario_setting.json
+++ b/ego/scenario_setting.json
@@ -1,67 +1,146 @@
 {
-    "eGo": {
-        "eTraGo": true,
-        "eDisGo": true,
-        "csv_import_eTraGo": false,
-        "csv_import_eDisGo": false,
+  "eGo": {
+    "eTraGo": true,
+    "eDisGo": true,
+    "csv_import_eTraGo": false,
+    "csv_import_eDisGo": false
+  },
+  "eTraGo": {
+    "db": "egon-data",
+    "gridversion": null,
+    "method": {
+        "type": "lopf",
+        "n_iter": 4,
+        "pyomo": true
     },
-    "eTraGo": {
-        "db": "oedb",
-        "gridversion": "v0.4.5",
-        "method": "lopf",
-        "pf_post_lopf": true,
-        "start_snapshot": 1000,
-        "end_snapshot": 1005,
-        "solver": "gurobi",
-        "solver_options": {},
-        "scn_name": "eGo 100",
-        "scn_extension": null,
-        "scn_decommissioning": null,
-        "lpfile": false,
-        "csv_export": "results/your_results",
-        "db_export": false,
-        "extendable": ["storage", "network"],
-        "generator_noise": 789456,
-        "minimize_loading": false,
-        "ramp_limits": false,
-        "extra_functionality": null,
-        "network_clustering_kmeans": 10,
-        "load_cluster": false,
-        "network_clustering_ehv": false,
-        "disaggregation": "uniform",
-        "snapshot_clustering": false,
-        "parallelisation": false,
-        "skip_snapshots": false,
-        "line_grouping": false,
-        "branch_capacity_factor": {"HV": 0.5, "eHV": 0.7},
-        "load_shedding": false,
-        "foreign_lines": {"carrier": "AC", "capacity": "osmTGmod"},
-        "comments": "",
+    "pf_post_lopf": {
+        "active": true,
+        "add_foreign_lopf": true,
+        "q_allocation": "p_nom"
     },
-    "eDisGo": {
-        "db": "oedb",
-        "gridversion": "v0.4.5",
-        "ding0_files": "/path/to_your/.dingo/grids",
-        "choice_mode": "cluster",
-        "cluster_attributes": [
-            "farthest_node",
-            "wind_cap",
-            "solar_cap",
-            "extended_storage",
+    "start_snapshot": 1,
+    "end_snapshot": 2,
+    "solver": "gurobi",
+    "solver_options": {
+        "BarConvTol": 1e-05,
+        "FeasibilityTol": 1e-05,
+        "method": 2,
+        "crossover": 0,
+        "logFile": "solver_etragos.log",
+        "threads": 4
+    },
+    "model_formulation": "kirchhoff",
+    "scn_name": "eGon2035",
+    "scn_extension": null,
+    "scn_decommissioning": null,
+    "lpfile": false,
+    "csv_export": "test",
+    "extendable": {
+        "extendable_components": [
+            "as_in_db"
         ],
-        "only_cluster": false,
-        "manual_grids": [],
-        "no_grids": 2,
-        "parallelization": true,
-        "max_calc_time": 0.5,
-        "max_workers": 2,
-        "initial_reinforcement": true,
-        "apply_curtailment": true,
-        "curtailment_voltage_threshold": 0,
-        "storage_distribution": true,
-        "max_cos_phi_renewable": 0.9,
-        "results": "results/another_result",
-        "solver": "gurobi",
-        "timesteps_pfa": "snapshot_analysis",
+        "upper_bounds_grid": {
+            "grid_max_D": null,
+            "grid_max_abs_D": {
+                "380": {
+                    "i": 1020,
+                    "wires": 4,
+                    "circuits": 4
+                },
+                "220": {
+                    "i": 1020,
+                    "wires": 4,
+                    "circuits": 4
+                },
+                "110": {
+                    "i": 1020,
+                    "wires": 4,
+                    "circuits": 2
+                },
+                "dc": 0
+            },
+            "grid_max_foreign": 4,
+            "grid_max_abs_foreign": null
+        }
     },
+    "generator_noise": 789456,
+    "extra_functionality": {},
+    "network_clustering": {
+        "random_state": 42,
+        "active": true,
+        "method": "kmedoids-dijkstra",
+        "n_clusters_AC": 30,
+        "cluster_foreign_AC": false,
+        "method_gas": "kmedoids-dijkstra",
+        "n_clusters_gas": 20,
+        "cluster_foreign_gas": false,
+        "k_busmap": false,
+        "kmeans_gas_busmap": false,
+        "line_length_factor": 1,
+        "remove_stubs": false,
+        "use_reduced_coordinates": false,
+        "bus_weight_tocsv": null,
+        "bus_weight_fromcsv": null,
+        "gas_weight_tocsv": null,
+        "gas_weight_fromcsv": null,
+        "n_init": 10,
+        "max_iter": 100,
+        "tol": 1e-06,
+        "CPU_cores": 4
+    },
+    "sector_coupled_clustering": {
+        "active": true,
+        "carrier_data": {
+            "central_heat": {
+                "base": [
+                    "CH4",
+                    "AC"
+                ],
+                "strategy": "simultaneous"
+            }
+        }
+    },
+    "network_clustering_ehv": false,
+    "disaggregation": "uniform",
+    "snapshot_clustering": {
+        "active": false,
+        "method": "segmentation",
+        "extreme_periods": null,
+        "how": "daily",
+        "storage_constraints": "soc_constraints",
+        "n_clusters": 5,
+        "n_segments": 5
+    },
+    "skip_snapshots": false,
+    "dispatch_disaggregation": false,
+    "branch_capacity_factor": {
+        "HV": 0.5,
+        "eHV": 0.7
+    },
+    "load_shedding": false,
+    "foreign_lines": {
+        "carrier": "AC",
+        "capacity": "osmTGmod"
+    },
+    "comments": null
+},
+  "eDisGo": {
+    "db": "oedb",
+    "gridversion": "v0.4.5",
+    "ding0_path": "/path/to_your/.dingo/grids",
+    "choice_mode": "cluster",
+    "cluster_attributes":["farthest_node", "wind_cap", "solar_cap", "extended_storage"],
+    "only_cluster": false,
+    "manual_grids": [],
+    "no_grids": 2,
+    "parallelization":true,
+    "max_calc_time": 0.5,
+    "max_workers":2,
+    "initial_reinforcement":true,
+    "max_cos_phi_renewable": 0.9,
+    "results": "results/another_result",
+    "solver": "gurobi",
+    "timesteps_pfa": "snapshot_analysis"
+  }
+
 }

--- a/ego/tools/plots.py
+++ b/ego/tools/plots.py
@@ -33,17 +33,6 @@ if not "READTHEDOCS" in os.environ:
 
     import pyproj as proj
 
-    from etrago.tools.plot import (
-        add_coordinates,
-        coloring,
-        curtailment,
-        gen_dist,
-        plot_line_loading,
-        plot_residual_load,
-        plot_stacked_gen,
-        plot_voltage,
-        storage_distribution,
-    )
     from geoalchemy2 import *
     from pypsa import Network as PyPSANetwork
     from shapely.geometry import MultiPolygon, Point, Polygon


### PR DESCRIPTION
This branch updates the interface to th current dev branch of eTraGo. 
If the current dev branches of eTraGo and eDisGo are installed, it is possible to run the etrago part of eGo with this branch. 

Open questions:
- installation/setup.py: refer to current eTraGo dev? 
- process-dependency links to pypsa fork can be dropped