### PR TITLE
Features/#162 update installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,9 @@ can be found on
 Installation
 ------------
 
+The last eGo release is quite old, and might not work anymore.
+Please use the developer installation, which is described below.
+
 .. code-block::
 
    $ pip3 install eGo --process-dependency-links
@@ -46,7 +49,7 @@ Create a virtualenvironment and activate it:
 
 .. code-block::
 
-   $ virtualenv venv --clear -p python3.8
+   $ virtualenv venv --clear -p python3.10
    $ source venv/bin/activate
    $ cd path/to/eGo
    $ python -m pip install -e .[full]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 # flake8: noqa: F401, F601
 import os
 
-from pip._internal.req import parse_requirements
 from setuptools import find_packages, setup
 
 __copyright__ = (

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-req = []
+req = [
+    "etrago @ git+https://github.com/openego/eTraGo.git@dev#egg=etrago",
+    "edisgo @ git+https://github.com/openego/eDisGo.git@dev#egg=edisgo",
+]
 
 dev_req = [
     "pre-commit",


### PR DESCRIPTION
Fixes #162 

With this branch, eGo installs the current dev branches of eTraGo and eDisGo. 
It is compatible to python3.10.

I updated the documentation only in the readme. Further changes in the read the docs are needed later on. (#163 )