### PR TITLE
Temporal complexity reduction: inject timestep selection into per-grid eDisGo runs

### DIFF
--- a/ego/scenario_setting_uc5_example.json
+++ b/ego/scenario_setting_uc5_example.json
@@ -91,6 +91,13 @@
     "import_electromobility": true
   },
 
+  "database": {
+    "database_name": "oedb",
+    "host": "",
+    "port": "",
+    "user": "",
+    "password": ""
+  },
 
   "ssh": {
     "enabled": false,

--- a/ego/scenario_setting_uc5_example.json
+++ b/ego/scenario_setting_uc5_example.json
@@ -1,0 +1,105 @@
+{
+  "_comment": "UC5: eDisGo with configurable timestep selection (uc5_select_timesteps preset). Runs setup -> imports -> oedb_ts -> build_flexibility_bands -> overlying grid -> select_timesteps -> OPF -> reinforce -> save, per grid. No eTraGo, no OPF-less path. Supports multiple grids with a default timeseries_selection and optional per-grid manual overrides.",
+  "_workflow": [
+    "Runs the bundled eDisGo preset 'uc5_select_timesteps' once per grid in eDisGo.manual_grids.",
+    "Timestep selection is configured via eDisGo.timeseries_selection (the DEFAULT applied to every grid).",
+    "eDisGo.timeseries_selection_per_grid optionally overrides the selection for individual grids",
+    "  (keyed by MV grid id as a string). A grid without an entry uses the default.",
+    "This lets you e.g. auto-select critical weeks for most grids but pin explicit manual timestamps",
+    "  for specific grids you want to inspect."
+  ],
+
+  "eGo": {
+    "eTraGo": false,
+    "eDisGo": true,
+    "csv_import_eTraGo": false,
+    "csv_import_eDisGo": false,
+    "random_seed": 42
+  },
+
+  "eTraGo": {
+    "scn_name": "eGon2035",
+    "db": "egon-data",
+    "extendable": []
+  },
+
+  "eDisGo": {
+    "preset": "uc5_select_timesteps",
+    "grid_path": "/home/gurobi/.ding0/2024-07-25T17:38:34_new_planning_new_edisgo/ding0_grids/",
+    "overlying_grid": true,
+    "overlying_grid_source": "/storage/JoDa/edisgo_playground/overlying_grid_data",
+    "legacy_ding0_grids": false,
+    "choice_mode": "manual",
+    "cluster_attributes": [],
+    "only_cluster": false,
+    "manual_grids": [32377, 32355],
+    "n_clusters": 1,
+    "parallelization": false,
+    "max_calc_time": 1.0,
+    "max_workers": 1,
+    "max_cos_phi_renewable": 0.9,
+
+    "results": "/storage/MS/ego/eGo/results/ego_uc5",
+    "solver": "gurobi",
+    "gridversion": null,
+
+    "_comment_timeseries_selection": "DEFAULT timestep selection applied to every grid unless overridden per grid below. mode: 'auto' (method 'power_flow' or 'residual_load') or 'manual' (timestamps list, or start/periods/end/freq range).",
+    "timeseries_selection": {
+      "mode": "auto",
+      "method": "residual_load",
+      "time_steps_per_time_interval": 168,
+      "time_step_day_start": 4,
+      "percentage": 1.0,
+      "save_steps": true,
+      "use_troubleshooting_mode": true,
+      "overloading_factor": 0.95,
+      "voltage_deviation_factor": 0.95
+    },
+
+    "_comment_timeseries_selection_per_grid": "OPTIONAL per-grid overrides of the default above, keyed by MV grid id (string). A grid not listed here uses eDisGo.timeseries_selection. Example: pin explicit manual timestamps for grid 32355 while 32377 uses the auto default.",
+    "timeseries_selection_per_grid": {
+      "32355": {
+        "mode": "manual",
+        "start": "2035-01-15 00:00",
+        "periods": 24,
+        "freq": "h"
+      }
+    },
+
+    "tasks": [
+      "1_setup_grid",
+      "base_reinforce",
+      "import_generators_from_db",
+      "import_home_batteries_from_db",
+      "import_heat_pumps_from_db",
+      "import_dsm_from_db",
+      "import_electromobility_from_db",
+      "apply_heat_pump_strategy",
+      "oedb_ts",
+      "reactive_power",
+      "check_integrity",
+      "optimize",
+      "5_grid_reinforcement",
+      "save"
+    ],
+
+    "_comment_flags": " ",
+    "import_generators": true,
+    "import_heat_pumps": true,
+    "import_home_batteries": true,
+    "import_dsm": true,
+    "import_electromobility": true
+  },
+
+
+  "ssh": {
+    "enabled": false,
+    "user": "",
+    "ip": "",
+    "port": "",
+    "local_address": "127.0.0.1",
+    "local_port": "59510"
+  },
+
+  "external_config": null
+}

--- a/ego/tools/edisgo_integration.py
+++ b/ego/tools/edisgo_integration.py
@@ -671,6 +671,18 @@ class EDisGoNetworks:
                 cfg["overlying_grid"] = {"enabled": False}
         else:
             cfg["overlying_grid"] = {"enabled": False}
+
+        # Timestep selection (uc5): a default block applied to every grid, with
+        # optional per-grid overrides keyed by MV grid id. Injected as the
+        # top-level ``timeseries_selection`` block the eDisGo select_timesteps
+        # task reads from ``ctx.raw_config`` — mirroring the overlying_grid
+        # injection above.
+        edisgo_cfg = self._json_file.get("eDisGo", {})
+        ts_default = edisgo_cfg.get("timeseries_selection")
+        ts_per_grid = edisgo_cfg.get("timeseries_selection_per_grid", {}) or {}
+        ts_selection = ts_per_grid.get(str(mv_grid_id), ts_default)
+        if ts_selection is not None:
+            cfg["timeseries_selection"] = ts_selection
         return cfg
 
     def _run_one_grid_via_runner(self, mv_grid_id):


### PR DESCRIPTION
## What

Partial solution to #189 — the **temporal** complexity reduction only
(spatial reduction remains open in that issue).

Wires the eDisGo run pipeline's configurable timestep selection
(openego/eDisGo#663) through to eGo's per-grid runner.
`EDisGoNetworks._build_run_edisgo_config` now injects a top-level
`timeseries_selection` block into each grid's runner config, mirroring the
existing `overlying_grid` injection. The block resolves per grid from the
scenario setting:

- `eDisGo.timeseries_selection` — a **default** applied to every grid.
- `eDisGo.timeseries_selection_per_grid` — optional **per-grid overrides**,
  keyed by MV grid id (string). A grid's entry fully replaces the default.

If neither is present, no block is injected and eDisGo keeps its full-year
behaviour, so the change is backward compatible.

## Why

Full-year optimization/reinforcement over every MVLV grid is prohibitively
expensive for the eGo milestone. This lets a run reduce each grid to a few
critical time intervals (auto `power_flow` / `residual_load`) or pin
specific grids to a manual time series — mixing both in one run.

## Example

`scenario_setting_uc5_example.json` (added) shows the feature: a
`residual_load` auto default for all grids plus a manual 24-step override
for grid `32355`.

## Scope / follow-up

- Depends on openego/eDisGo#663 (the eDisGo `select_timesteps` task that
  reads the `timeseries_selection` block). This PR is only the config
  plumbing on the eGo side.
- Spatial complexity reduction (the other half of #189) is not included.

## Testing

- Config injection verified against the uc5 scenario (default vs per-grid
  override resolution).
- Backward compatibility: scenarios without a `timeseries_selection` block
  produce an unchanged runner config.

Part of #189.

