### PR TITLE
189 spatial complexity reduction

### DIFF
--- a/ego/appl.py
+++ b/ego/appl.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     logger.info("Start calculation")
 
     # Initialize eGo object
-    ego = eGo(jsonpath="scenario_setting_mv_clustering.json")
+    ego = eGo(jsonpath="scenario_setting_uc6_example.json")
 
     # Run eGo
     ego.run()

--- a/ego/scenario_setting_uc6_example.json
+++ b/ego/scenario_setting_uc6_example.json
@@ -92,6 +92,13 @@
     "import_electromobility": true
   },
 
+  "database": {
+    "database_name": "oedb",
+    "host": "",
+    "port": "",
+    "user": "",
+    "password": ""
+  },
 
   "ssh": {
     "enabled": false,

--- a/ego/scenario_setting_uc6_example.json
+++ b/ego/scenario_setting_uc6_example.json
@@ -35,7 +35,7 @@
     "choice_mode": "manual",
     "cluster_attributes": [],
     "only_cluster": false,
-    "manual_grids": [32377],
+    "manual_grids": [32377, 32355],
     "n_clusters": 1,
     "parallelization": false,
     "max_calc_time": 1.0,

--- a/ego/scenario_setting_uc6_example.json
+++ b/ego/scenario_setting_uc6_example.json
@@ -1,0 +1,106 @@
+{
+  "_comment": "UC6: eDisGo with spatial complexity reduction bracketing the OPF step (uc6_spatial_reduction preset). Runs setup -> imports -> oedb_ts -> build_flexibility_bands -> overlying grid -> select_timesteps -> reactive_power -> spatial_reduce -> OPF -> spatial_restore -> reinforce -> save, per grid. No eTraGo, no OPF-less path. Supports multiple grids with a default spatial_reduction and optional per-grid overrides.",
+  "_workflow": [
+    "Runs the bundled eDisGo preset 'uc6_spatial_reduction' once per grid in eDisGo.manual_grids.",
+    "Spatial reduction is configured via eDisGo.spatial_reduction (the DEFAULT applied to every grid).",
+    "eDisGo.spatial_reduction_per_grid optionally overrides the selection for individual grids",
+    "  (keyed by MV grid id as a string). A grid without an entry uses the default.",
+    "spatial_reduce/spatial_restore bracket optimize: the OPF runs on a spatially-reduced grid,",
+    "  then the optimized dispatch is mapped back onto the full topology for reinforce.",
+    "aggregation_mode: false merges no components (by-name restore) - use this for now;",
+    "  aggregation_mode: true has a known gap with charging points, see",
+    "  docs_notes/issue_aggregation_mode_flexibility_bands_not_aggregated.md in the eDisGo repo."
+  ],
+
+  "eGo": {
+    "eTraGo": false,
+    "eDisGo": true,
+    "csv_import_eTraGo": false,
+    "csv_import_eDisGo": false,
+    "random_seed": 42
+  },
+
+  "eTraGo": {
+    "scn_name": "eGon2035",
+    "db": "egon-data",
+    "extendable": []
+  },
+
+  "eDisGo": {
+    "preset": "uc6_spatial_reduction",
+    "grid_path": "/home/gurobi/.ding0/2024-07-25T17:38:34_new_planning_new_edisgo/ding0_grids/",
+    "overlying_grid": true,
+    "overlying_grid_source": "/storage/JoDa/edisgo_playground/overlying_grid_data",
+    "legacy_ding0_grids": false,
+    "choice_mode": "manual",
+    "cluster_attributes": [],
+    "only_cluster": false,
+    "manual_grids": [32377],
+    "n_clusters": 1,
+    "parallelization": false,
+    "max_calc_time": 1.0,
+    "max_workers": 1,
+    "max_cos_phi_renewable": 0.9,
+
+    "results": "/storage/MS/ego/eGo/results/ego_uc6",
+    "solver": "gurobi",
+    "gridversion": null,
+
+    "_comment_timeseries_selection": "DEFAULT timestep selection applied to every grid unless overridden per grid below. Manual mode with a short window keeps the OPF fast for this example.",
+    "timeseries_selection": {
+      "mode": "manual",
+      "start": "2035-01-15 00:00",
+      "periods": 24,
+      "freq": "h"
+    },
+
+    "_comment_spatial_reduction": "DEFAULT spatial complexity reduction applied to every grid unless overridden per grid below. aggregation_mode: false merges no components (by-name restore); true also merges loads/generators at the same bus (disaggregated restore) - see docs_notes/issue_aggregation_mode_flexibility_bands_not_aggregated.md for a known gap with aggregation_mode=true and charging points.",
+    "spatial_reduction": {
+      "enabled": true,
+      "mode": "kmeansdijkstra",
+      "cluster_area": "feeder",
+      "reduction_factor": 0.3,
+      "reduction_factor_not_focused": false,
+      "aggregation_mode": false
+    },
+
+    "_comment_spatial_reduction_per_grid": "OPTIONAL per-grid overrides of the default above, keyed by MV grid id (string). A grid not listed here uses eDisGo.spatial_reduction. Example: disable spatial reduction for a specific grid while others use the default.",
+    "spatial_reduction_per_grid": {},
+
+    "tasks": [
+      "1_setup_grid",
+      "base_reinforce",
+      "import_generators_from_db",
+      "import_home_batteries_from_db",
+      "import_heat_pumps_from_db",
+      "import_dsm_from_db",
+      "import_electromobility_from_db",
+      "apply_heat_pump_strategy",
+      "oedb_ts",
+      "reactive_power",
+      "check_integrity",
+      "optimize",
+      "5_grid_reinforcement",
+      "save"
+    ],
+
+    "_comment_flags": " ",
+    "import_generators": true,
+    "import_heat_pumps": true,
+    "import_home_batteries": true,
+    "import_dsm": true,
+    "import_electromobility": true
+  },
+
+
+  "ssh": {
+    "enabled": false,
+    "user": "",
+    "ip": "",
+    "port": "",
+    "local_address": "127.0.0.1",
+    "local_port": "59510"
+  },
+
+  "external_config": null
+}

--- a/ego/tools/edisgo_integration.py
+++ b/ego/tools/edisgo_integration.py
@@ -683,6 +683,16 @@ class EDisGoNetworks:
         ts_selection = ts_per_grid.get(str(mv_grid_id), ts_default)
         if ts_selection is not None:
             cfg["timeseries_selection"] = ts_selection
+
+        # Spatial complexity reduction (uc6): same default + per-grid-override
+        # pattern as timeseries_selection above. Injected as the top-level
+        # ``spatial_reduction`` block the eDisGo spatial_reduce/spatial_restore
+        # tasks read from ``ctx.raw_config``.
+        spatial_default = edisgo_cfg.get("spatial_reduction")
+        spatial_per_grid = edisgo_cfg.get("spatial_reduction_per_grid", {}) or {}
+        spatial_reduction = spatial_per_grid.get(str(mv_grid_id), spatial_default)
+        if spatial_reduction is not None:
+            cfg["spatial_reduction"] = spatial_reduction
         return cfg
 
     def _run_one_grid_via_runner(self, mv_grid_id):

--- a/tests/tools/test_edisgo_integration.py
+++ b/tests/tools/test_edisgo_integration.py
@@ -1,0 +1,63 @@
+import logging
+
+from ego.tools.edisgo_integration import EDisGoNetworks
+
+logger = logging.getLogger(__name__)
+
+
+def _make_networks(edisgo_args):
+    """
+    Build an EDisGoNetworks instance without running __init__ (which would
+    immediately kick off a full eDisGo pool run) - only the attributes
+    _build_run_edisgo_config actually reads are set.
+    """
+    networks = EDisGoNetworks.__new__(EDisGoNetworks)
+    networks._json_file = {"eDisGo": edisgo_args}
+    networks._scn_name = "eGon2035"
+    networks._grid_path = "/some/grid/path"
+    networks._results = "/some/results/path"
+    networks._preset = edisgo_args.get("preset")
+    return networks
+
+
+class TestBuildRunEdisgoConfig:
+    def test_no_spatial_reduction_block_when_absent(self):
+        networks = _make_networks({"preset": "uc5_select_timesteps"})
+        cfg = networks._build_run_edisgo_config(32377)
+        assert "spatial_reduction" not in cfg
+
+    def test_default_spatial_reduction_applied_to_every_grid(self):
+        default = {"enabled": True, "mode": "kmeansdijkstra", "reduction_factor": 0.3}
+        networks = _make_networks(
+            {"preset": "uc6_spatial_reduction", "spatial_reduction": default}
+        )
+        assert networks._build_run_edisgo_config(32377)["spatial_reduction"] == default
+        assert networks._build_run_edisgo_config(32355)["spatial_reduction"] == default
+
+    def test_per_grid_override_wins_for_listed_grid(self):
+        default = {"enabled": True, "mode": "kmeansdijkstra", "reduction_factor": 0.3}
+        override = {"enabled": False}
+        networks = _make_networks(
+            {
+                "preset": "uc6_spatial_reduction",
+                "spatial_reduction": default,
+                "spatial_reduction_per_grid": {"32355": override},
+            }
+        )
+        # listed grid gets the override, whole-block replacement (not merged)
+        assert networks._build_run_edisgo_config(32355)["spatial_reduction"] == override
+        # unlisted grid still gets the default
+        assert networks._build_run_edisgo_config(32377)["spatial_reduction"] == default
+
+    def test_omitted_entirely_if_neither_default_nor_override_set(self):
+        networks = _make_networks(
+            {
+                "preset": "uc6_spatial_reduction",
+                "spatial_reduction_per_grid": {"32355": {"enabled": False}},
+            }
+        )
+        # 32355 has an explicit override -> present
+        assert "spatial_reduction" in networks._build_run_edisgo_config(32355)
+        # 32377 has neither a default nor an override -> key omitted, letting
+        # the eDisGo preset's own default apply
+        assert "spatial_reduction" not in networks._build_run_edisgo_config(32377)


### PR DESCRIPTION
Companion to the eDisGo spatial-complexity-reduction pipeline integration (openego/eDisGo#705). Adds the eGo-side config injection so `spatial_reduction`/`spatial_reduction_per_grid` reach eDisGo's run pipeline the same way `timeseries_selection` already does.

## Summary

- `EDisGoNetworks._build_run_edisgo_config` now injects a `spatial_reduction` block into the per-grid eDisGo config, mirroring the existing `timeseries_selection` injection exactly: a global `eDisGo.spatial_reduction` default applied to every grid, with optional `eDisGo.spatial_reduction_per_grid` overrides keyed by MV grid id (whole-block replacement, not a field-level merge). The key is omitted entirely if neither is set, so the eDisGo preset's own default applies.
- New `scenario_setting_uc6_example.json`, based on the existing uc5 example, demonstrating the new preset (`uc6_spatial_reduction`) and config block. Kept as a separate file rather than modifying `scenario_setting_uc5_example.json`, so the uc5 example stays a pure timeseries-selection example.
- Unit tests for the injection logic (`tests/tools/test_edisgo_integration.py`): default applied to every grid, per-grid override winning for a listed grid, and the key being omitted when neither default nor override is set.

## Testing

- [x] New unit tests pass (4/4)
- [x] Verified end-to-end against real grid `32377` through eGo (`scenario_setting_uc6_example.json`): the full pipeline — `spatial_reduce` → `optimize` (Gurobi) → `spatial_restore` → `reinforce` → `save` — completed successfully

## Related

- eDisGo PR: partial solution to openego/eDisGo#705
- Known limitation carried over from the eDisGo side: `aggregation_mode: true` has a gap with charging points (not fixed there yet), so the example config defaults to `aggregation_mode: false`
